### PR TITLE
Renovate/auto merge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,23 @@
       "matchPackageNames": ["netboxcommunity/netbox"],
       "versioning": "semver",
       "allowedVersions": "<4.4.0"
+    },
+    {
+      "description": "Automerge non-major updates",
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["patch", "digest"],
+      "automerge": true,
+      "automergeType": "pr",
+      "requiredStatusChecks": [
+        "codespell",
+        "super-linter",
+        "shiftleft",
+        "test-build",
+        "Run test",
+        "Run Dockle tests",
+        "Run Trivy tests",
+        "Run Anchore tests"
+      ]
     }
   ]
 }

--- a/.github/workflows/docker.image.yml
+++ b/.github/workflows/docker.image.yml
@@ -53,6 +53,7 @@ jobs:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_CHECKOV: false
+          VALIDATE_RENOVATE: false
   shiftleft:
     name: shiftleft
     strategy:


### PR DESCRIPTION
## Summary by Sourcery

Disable Renovate validation in the Docker CI workflow and configure Renovate to auto-merge dependency updates

New Features:
- Enable auto-merging in the Renovate configuration

Enhancements:
- Add a VALIDATE_RENOVATE environment variable to the Docker image workflow and set it to false

CI:
- Disable the Renovate validation step in the CI pipeline by default